### PR TITLE
Add support for Laravel 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a reimplementation of [jamesmills/laravel-timezone](https://github.dev/j
 
 ## Requirements
 
-Supported Laravel versions 9.x and 10.x
+Supported Laravel versions 9.x, 10.x and 11.x
 
 ## How does it work
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   },
     "require": {
         "php": "^8.0|^8.1|^8.2|^8.3",
-        "laravel/framework": "^9.0|^10.0",
+        "laravel/framework": "^9.0|^10.0|^11.0",
         "nesbot/carbon": "^2.0|^3.0",
         "torann/geoip": "^3.0"
     },


### PR DESCRIPTION
Since `torann/geoip` now supports Laravel 11, this commit adds support back to package.